### PR TITLE
fixes for mathcomp 1.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,10 @@ env:
   - DOCKERIMAGE="mathcomp/mathcomp:1.9.0-coq-8.8"
   - DOCKERIMAGE="mathcomp/mathcomp:1.9.0-coq-8.9"
   - DOCKERIMAGE="mathcomp/mathcomp:1.9.0-coq-8.10"
-  # - DOCKERIMAGE="mathcomp/mathcomp:1.8.0-coq-dev"
+  - DOCKERIMAGE="mathcomp/mathcomp-dev:coq-8.7"
+  - DOCKERIMAGE="mathcomp/mathcomp-dev:coq-8.8"
+  - DOCKERIMAGE="mathcomp/mathcomp-dev:coq-8.9"
+  - DOCKERIMAGE="mathcomp/mathcomp-dev:coq-8.10"
 
 install: |
   # Prepare the COQ container

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ install: |
     opam list
     sudo chown -R coq:coq /home/coq/${CONTRIB_NAME}
     opam pin add -y -n coq-mathcomp-multinomials .
-    opam install -y -vvv --deps-only coq-mathcomp-multinomials
+    opam install -y -vvv --deps-only --ignore-constraints-on "coq-mathcomp-ssreflect,coq-mathcomp-fingroup,coq-mathcomp-algebra,coq-mathcomp-solvable,coq-mathcomp-field" coq-mathcomp-multinomial
     "
 script:
 - echo -e "${ANSI_YELLOW}Building ${CONTRIB_NAME}...${ANSI_RESET}" && echo -en 'travis_fold:start:script\\r'
@@ -54,7 +54,7 @@ script:
     export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
     set -ex
     eval \$(opam env)
-    opam install -y -vvv coq-mathcomp-multinomials
+    opam install -y -vvv --ignore-constraints-on "coq-mathcomp-ssreflect,coq-mathcomp-fingroup,coq-mathcomp-algebra,coq-mathcomp-solvable,coq-mathcomp-field" coq-mathcomp-multinomials
     "
 - docker stop COQ  # optional
 - echo -en 'travis_fold:end:script\\r'

--- a/opam
+++ b/opam
@@ -16,7 +16,7 @@ install: [
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/SsrMultinomials"]
 depends: [
   "coq" {(>= "8.7" | < "8.11~")}
-  "coq-mathcomp-algebra" {(>= "1.8.0" & < "1.10~")}
+  "coq-mathcomp-algebra" {(>= "1.8.0" & < "1.11~") | (= "dev")}
   "coq-mathcomp-bigenough" {>= "1.0.0" & < "1.1~"}
   "coq-mathcomp-finmap"    {>= "1.3.4" & < "1.4~"}
 ]

--- a/opam
+++ b/opam
@@ -16,7 +16,8 @@ install: [
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/SsrMultinomials"]
 depends: [
   "coq" {(>= "8.7" | < "8.11~")}
-  "coq-mathcomp-algebra" {(>= "1.8.0" & < "1.11~") | (= "dev")}
+  "coq-mathcomp-ssreflect" {(>= "1.8.0" & < "1.11~") | (= "dev")}
+  "coq-mathcomp-algebra"
   "coq-mathcomp-bigenough" {>= "1.0.0" & < "1.1~"}
   "coq-mathcomp-finmap"    {>= "1.3.4" & < "1.4~"}
 ]

--- a/src/freeg.v
+++ b/src/freeg.v
@@ -222,17 +222,17 @@ Section FreegTheory.
     move=> s z x y neq_xy; elim: s => [|[z' x'] s IH] /=.
     + by move=> _; rewrite mem_seq1 eq_sym.
     + rewrite in_cons negb_or => /andP [neq_yx' Hys].
-      have [->|neq_xx'] := eqVneq x x'; rewrite ?eqxx /=.
+      have [->|neq_xx'] := altP (x =P x'); rewrite ?eqxx /=.
       * by rewrite in_cons negb_or neq_yx' Hys.
-      * by rewrite (negbTE neq_xx') /= in_cons (negbTE neq_yx') IH.
+      * by rewrite /= in_cons (negbTE neq_yx') IH.
   Qed.
 
   Lemma uniq_predom_augment s z x:
     uniq (predom s) -> uniq (predom (augment s z x)).
   Proof.
     elim: s => [|[z' x'] s ih] //=.
-    have [->|neq_xx'] := eqVneq x x'; rewrite ?eqxx //.
-    rewrite (negbTE neq_xx') /=; case/andP=> Hx's /ih ->.
+    have [->|neq_xx'] := altP (x =P x'); rewrite ?eqxx //=.
+    case/andP=> Hx's /ih ->.
     by rewrite andbT; apply mem_augment.
   Qed.
 
@@ -346,18 +346,18 @@ Section FreegTheory.
   Proof.
     elim: s => [|[k' x'] s ih] //=.
       by rewrite prelift_seq1 prelift_nil !simpm.
-    have [->|ne_xx'] := eqVneq x x'.
-      by rewrite eqxx !prelift_cons scalerDl addrA.
-      by rewrite (negbTE ne_xx') !prelift_cons ih addrCA.
+    have [->|ne_xx'] := altP (x =P x').
+      by rewrite !prelift_cons scalerDl addrA.
+      by rewrite !prelift_cons ih addrCA.
   Qed.
 
   Lemma prelift_reduce s: prelift (reduce s) = prelift s.
   Proof.
     rewrite /reduce; set S := foldr _ _ _; set rD := filter _ _.
     have ->: prelift rD = prelift S; rewrite ?/rD => {rD}.
-      elim: S => [//|[k x] S IH] /=; have [->|nz_k] := eqVneq k 0.
-        by rewrite eqxx /= prelift_cons scale0r !simpm.
-      by rewrite nz_k !prelift_cons IH.
+      elim: S => [//|[k x] S IH] /=; have [->|nz_k] := altP (k =P 0).
+        by rewrite /= prelift_cons scale0r !simpm.
+      by rewrite !prelift_cons IH.
     rewrite /S; elim: {S} s => [//|[k x] s ih].
     by rewrite prelift_cons /= prelift_augment ih.
   Qed.
@@ -444,9 +444,9 @@ Section FreegTheory.
   Lemma precoeff_outdom x s: x \notin predom s -> precoeff x s = 0.
   Proof.
     move=> x_notin_s; rewrite /precoeff big_seq_cond big_pred0 //.
-    case=> k z /=; have [->|/negbTE ->] := eqVneq z x; last first.
+    case=> k z /=; have [->|] := altP (z =P x); last first.
       by rewrite andbF.
-    rewrite eqxx andbT; apply/negP=> /(map_f (@snd _ _)).
+    rewrite andbT; apply/negP=> /(map_f (@snd _ _)).
     by rewrite (negbTE x_notin_s).
   Qed.
 
@@ -783,7 +783,7 @@ Section FreegZmodTypeTheory.
   Proof.
     move=> z; rewrite mem_cat !mem_dom !inE coeffD.
     have nz_sum (x1 x2 : R): x1 + x2 != 0 -> (x1 != 0) || (x2 != 0).
-      by have [->|->] := eqVneq x1 0; first by rewrite add0r eqxx.
+      by have [->|] := altP (x1 =P 0); first by rewrite add0r.
     by move/nz_sum; case/orP=> ->; rewrite ?orbT.
   Qed.
 

--- a/src/mpoly.v
+++ b/src/mpoly.v
@@ -5209,7 +5209,8 @@ have h (T : eqType) (leT : rel T) (s : seq T) (F : T -> nat) x:
   -> path leT x (flatten [seq nseq (F x) x | x <- s]).
 * move=> leTxx leT_tr; elim: s x => //= y s ih x /andP[le_xy pt_ys].
   case: (F y)=> /= [|k]; first apply/ih.
-    rewrite path_min_sorted; first by apply/(path_sorted (x := y)).
+    rewrite path_min_sorted; do ?apply: (introT allP).
+      by apply/(path_sorted (x := y)).
     move=> z z_in_s /=; apply/(leT_tr y)=> //.
     by move/order_path_min: pt_ys => /(_ leT_tr) /allP /(_ _ z_in_s).
   rewrite le_xy /= cat_path; apply/andP; split.
@@ -5224,7 +5225,8 @@ rewrite (map_path (e' := P) (b := xpred0)) //=; last first.
   by apply/hasP; case.
 apply/h; try solve [exact/leqnn | exact/leq_trans].
 rewrite -(map_path (h := val) (e := leq) (b := xpred0)) //.
-  by rewrite val_enum_ord /= path_min_sorted // iota_sorted.
+  rewrite val_enum_ord /= path_min_sorted ?iota_sorted//;
+  do ?exact: (introT allP).
 by apply/hasP; case.
 Qed.
 


### PR DESCRIPTION
Making multinomials compatible with mathcomp 1.10.0.
We may then release for mathcomp including 1.9.0.