### PR TITLE
Adaptation to mathcomp 1.11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install:
 - docker pull ${DOCKERIMAGE}
 - docker tag  ${DOCKERIMAGE} ci:current
 - docker run  --env=OPAMYES --init -id --name=CI -v ${TRAVIS_BUILD_DIR}:/home/coq/${CONTRIB} -w /home/coq/${CONTRIB} ci:current
+- docker exec CI /bin/bash --login -c "cd ..; curl -LO https://github.com/math-comp/finmap/archive/1.5.0.tar.gz; tar -xvzf 1.5.0.tar.gz; cd finmap-1.5.0/; opam pin add -y -n coq-mathcomp-finmap.1.5.0 .; opam install coq-mathcomp-finmap.1.5.0; cd /home/coq/${CONTRIB}" # remove this line when finmap-1.5.0 is merged in opam coq archive
 - docker exec CI /bin/bash --login -c "opam pin add -n coq-mathcomp-${CONTRIB} ."
 - docker exec CI /bin/bash --login -c "opam install --deps-only coq-mathcomp-${CONTRIB}"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,6 @@ env:
   - DOCKERIMAGE="mathcomp/mathcomp:1.11.0-coq-8.9"
   - DOCKERIMAGE="mathcomp/mathcomp:1.11.0-coq-8.10"
   - DOCKERIMAGE="mathcomp/mathcomp:1.11.0-coq-8.11"
-  - DOCKERIMAGE="mathcomp/mathcomp-dev:coq-8.7"
-  - DOCKERIMAGE="mathcomp/mathcomp-dev:coq-8.8"
-  - DOCKERIMAGE="mathcomp/mathcomp-dev:coq-8.9"
-  - DOCKERIMAGE="mathcomp/mathcomp-dev:coq-8.10"
-  - DOCKERIMAGE="mathcomp/mathcomp-dev:coq-8.11"
 
 install:
 - docker pull ${DOCKERIMAGE}

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,16 @@ env:
   - CONTRIB="multinomials"
   - OPAMYES=yes
   jobs:
-  - DOCKERIMAGE="mathcomp/mathcomp:1.8.0-coq-8.7"
-  - DOCKERIMAGE="mathcomp/mathcomp:1.8.0-coq-8.8"
-  - DOCKERIMAGE="mathcomp/mathcomp:1.8.0-coq-8.9"
-  - DOCKERIMAGE="mathcomp/mathcomp:1.9.0-coq-8.7"
-  - DOCKERIMAGE="mathcomp/mathcomp:1.9.0-coq-8.8"
-  - DOCKERIMAGE="mathcomp/mathcomp:1.9.0-coq-8.9"
-  - DOCKERIMAGE="mathcomp/mathcomp:1.9.0-coq-8.10"
-  - DOCKERIMAGE="mathcomp/mathcomp:1.10.0-coq-8.7"
-  - DOCKERIMAGE="mathcomp/mathcomp:1.10.0-coq-8.8"
-  - DOCKERIMAGE="mathcomp/mathcomp:1.10.0-coq-8.9"
-  - DOCKERIMAGE="mathcomp/mathcomp:1.10.0-coq-8.10"
+  - DOCKERIMAGE="mathcomp/mathcomp:1.11.0-coq-8.7"
+  - DOCKERIMAGE="mathcomp/mathcomp:1.11.0-coq-8.8"
+  - DOCKERIMAGE="mathcomp/mathcomp:1.11.0-coq-8.9"
+  - DOCKERIMAGE="mathcomp/mathcomp:1.11.0-coq-8.10"
+  - DOCKERIMAGE="mathcomp/mathcomp:1.11.0-coq-8.11"
+  - DOCKERIMAGE="mathcomp/mathcomp-dev:coq-8.7"
+  - DOCKERIMAGE="mathcomp/mathcomp-dev:coq-8.8"
+  - DOCKERIMAGE="mathcomp/mathcomp-dev:coq-8.9"
+  - DOCKERIMAGE="mathcomp/mathcomp-dev:coq-8.10"
+  - DOCKERIMAGE="mathcomp/mathcomp-dev:coq-8.11"
 
 install:
 - docker pull ${DOCKERIMAGE}

--- a/opam
+++ b/opam
@@ -14,11 +14,11 @@ install: [
   [make "install"]
 ]
 depends: [
-  "coq" {(>= "8.7" & < "8.11~")}
-  "coq-mathcomp-ssreflect" {>= "1.8.0" & < "1.11~"}
+  "coq" {(>= "8.7" & < "8.12~")}
+  "coq-mathcomp-ssreflect" {>= "1.11.0" & < "1.12~"}
   "coq-mathcomp-algebra"
   "coq-mathcomp-bigenough" {>= "1.0.0" & < "1.1~"}
-  "coq-mathcomp-finmap"    {>= "1.4" & < "1.5~"}
+  "coq-mathcomp-finmap"    {>= "1.5" & < "1.6~"}
 ]
 tags: [
   "keyword:multinomials"


### PR DESCRIPTION
- many ssrcomplements lemma have been exported to mathcomp, using them
- replaced deprecated symbols by their new names
- adapted to the new order.v (treatments of Num.max got better)