### PR TITLE
[opam] allow dev dependencies

### DIFF
--- a/coq-mathcomp-multinomials.opam
+++ b/coq-mathcomp-multinomials.opam
@@ -8,12 +8,12 @@ license: "CeCILL-B"
 authors: ["Pierre-Yves Strub"]
 build: [ "dune" "build" "-p" name "-j" jobs ]
 depends: [
-  "coq"                    {>= "8.10" & < "8.14~"}
+  "coq"                    {(>= "8.10" & < "8.14~") | = "dev"}
   "dune"                   {>= "2.5"}
-  "coq-mathcomp-ssreflect" {>= "1.12" & < "1.13~"}
+  "coq-mathcomp-ssreflect" {(>= "1.12" & < "1.13~") | = "dev"}
   "coq-mathcomp-algebra"
-  "coq-mathcomp-bigenough" {>= "1.0" & < "1.1~"}
-  "coq-mathcomp-finmap"    {>= "1.5" & < "1.6~"}
+  "coq-mathcomp-bigenough" {(>= "1.0" & < "1.1~") | = "dev"}
+  "coq-mathcomp-finmap"    {(>= "1.5" & < "1.6~") | = "dev"}
 ]
 tags: [
   "keyword:multinomials"


### PR DESCRIPTION
In order to make it possible for mathcomp CI to test them.
cf https://github.com/math-comp/math-comp/pull/692