### PR TITLE
fix: Use coq_makefile instead of dune, temporarily

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,18 @@
 # -*- Makefile -*-
 
-# --------------------------------------------------------------------
-DUNEOPTS ?=
-DUNE     := dune $(DUNEOPTS)
+all: Makefile.coq
+	+make -f Makefile.coq all
 
-# --------------------------------------------------------------------
-.PHONY: default build clean
+clean: Makefile.coq
+	+make -f Makefile.coq clean
+	rm -f Makefile.coq Makefile.coq.conf
 
-default: build
+_CoqProject:;
 
-build:
-	$(DUNE) build
+Makefile.coq: _CoqProject
+	$(COQBIN)coq_makefile -f _CoqProject -o Makefile.coq
 
-clean:
-	$(DUNE) clean
+%: Makefile.coq
+	+make -f Makefile.coq $@
+
+.PHONY: all clean

--- a/_CoqProject
+++ b/_CoqProject
@@ -3,4 +3,11 @@
 -arg -w -arg -redundant-canonical-projection
 -arg -w -arg -projection-no-head-constant
 
--R _build/default/src SsrMultinomials
+# -R _build/default/src SsrMultinomials
+-R src SsrMultinomials
+
+src/ssrcomplements.v
+src/monalg.v
+src/xfinmap.v
+src/mpoly.v
+src/freeg.v

--- a/coq-mathcomp-multinomials.opam
+++ b/coq-mathcomp-multinomials.opam
@@ -6,7 +6,11 @@ bug-reports: "https://github.com/math-comp/multinomials/issues"
 dev-repo: "git+https://github.com/math-comp/multinomials.git"
 license: "CeCILL-B"
 authors: ["Pierre-Yves Strub"]
-build: [ "dune" "build" "-p" name "-j" jobs ]
+# build: [ "dune" "build" "-p" name "-j" jobs ]
+
+build: [make "-j%{jobs}%"]
+install: [make "install"]
+
 depends: [
   "coq"                    {(>= "8.10" & < "8.14~") | = "dev"}
   "dune"                   {>= "2.5"}


### PR DESCRIPTION
Dear Multinomials maintainers — Cc @strub @CohenCyril,

* I've recently attempted to migrate my opam switches to Coq 8.13, but CoqEAL doesn't compile out-of-the-box because of the current build system of coq-multinomials which does not install the required `.coq-native/*` files.
* I know this may seem orthogonal to the role of the multinomials library, but it happens *all transitive dependencies* of a given library (such as CoqEAL or ValidSDP) need to install these additional files for the build to be successful;
* As mentioned in [the CEP 48](https://github.com/coq/ceps/blob/master/text/048-packaging-coq-native.md), the current best solution to achieve this just amounts to using `coq_makefile`.

Hence this PR (using `coq_makefile` instead of `dune` for the time being).

<details><summary>Commit details</summary>

`fix: Use coq_makefile instead of dune, temporarily`

* Otherwise, with (coq.8.13.2 + coq-native):

```
  #=== ERROR while compiling coq-coqeal.1.0.5 ===================================#
  # [...]
  # File "./refinements/multipoly.v", line 1532, characters 0-67:
  # Warning: Duplicate clear of sz_m' [duplicate-clear,ssr]
  # File "./refinements/.coq-native/NCoqEAL_refinements_multipoly.native", line 66, characters 14-82:
  # Error: Unbound module NSsrMultinomials_mpoly
  # Error: Native compiler exited with status 2
```

* This fix is temporary: when multinomials will require Coq >= 8.12.1, one could then rely on https://github.com/ocaml/dune/pull/3210, which provides the `(mode native)` stanza.

* For details, see also: https://github.com/coq/ceps/pull/48

</details>

If the content of my PR looks good to you, It'd be awesome to have a 1.5.5-or-so point release :-)