### PR TITLE
Remove old capitalized syntax for instantiate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
               coq_native_compiler_default && echo native-compiler
               coq_native=$(opam var coq-native:installed)
             endGroup
-            if [ "$coq_native" = "true" ] && le_version "8.12.1" "$coqv"; then
+            if [ "$coq_native" = "true" ] && le_version "8.13.0" "$coqv"; then
               startGroup "Workaround permission issue"
                 sudo chown -R coq:coq .  # <--(§)
               endGroup

--- a/coq-mathcomp-multinomials.opam
+++ b/coq-mathcomp-multinomials.opam
@@ -6,9 +6,7 @@ dev-repo: "git+https://github.com/math-comp/multinomials.git"
 license: "CeCILL-B"
 authors: ["Pierre-Yves Strub"]
 build: [
-  [ "bash" "./configure"
-    "--native-compiler" {coq-native:installed & coq:version >= "8.12.1" & coq:version < "8.13~" }
-    "yes" {coq-native:installed & coq:version >= "8.12.1" & coq:version < "8.13~" } ]
+  [ "bash" "./configure" ]
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [

--- a/src/xfinmap.v
+++ b/src/xfinmap.v
@@ -34,5 +34,5 @@ Ltac done := do [fset_big_enough_trans|BigEnough.done].
 
 Ltac pose_big_fset K i :=
   evar (i : {fset K}); suff : closed i; first do
-    [move=> _; instantiate (1 := bigger_than (@fsubset K) _) in (Value of i)].
+    [move=> _; instantiate (1 := bigger_than (@fsubset K) _) in (value of i)].
 End BigEnoughFSet.


### PR DESCRIPTION
This was deprecated in coq more than three years ago in
https://github.com/coq/coq/pull/8110 and removed recently
https://github.com/coq/coq/pull/15193 (so will disappear in 8.16).