### PR TITLE
Allow Coq 8.15 in the OPAM file

### DIFF
--- a/coq-mathcomp-multinomials.opam
+++ b/coq-mathcomp-multinomials.opam
@@ -10,7 +10,7 @@ build: [
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
-  "coq"                    {(>= "8.10" & < "8.15~") | = "dev"}
+  "coq"                    {(>= "8.10" & < "8.16~") | = "dev"}
   "dune"                   {>= "2.5"}
   "coq-mathcomp-ssreflect" {(>= "1.12" & < "1.14~") | = "dev"}
   "coq-mathcomp-algebra"


### PR DESCRIPTION
Although Docker images are not available yet, I locally tested that multinomials.dev is compatible with Coq 8.15+rc1 and MathComp 1.13.0.