### PR TITLE
Push dune version bound in opam file

### DIFF
--- a/coq-mathcomp-multinomials.opam
+++ b/coq-mathcomp-multinomials.opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "coq"                    {(>= "8.10" & < "8.16~") | = "dev"}
-  "dune"                   {>= "2.5"}
+  "dune"                   {>= "2.8"}
   "coq-mathcomp-ssreflect" {(>= "1.12" & < "1.14~") | = "dev"}
   "coq-mathcomp-algebra"
   "coq-mathcomp-bigenough" {(>= "1.0" & < "1.1~") | = "dev"}


### PR DESCRIPTION
To make it consistent with the one in the dune-project file.
Just noticed that detail while submitting the OPAM package for 1.5.5.
