### PR TITLE
Compile with Coq master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
           - mathcomp/mathcomp:1.15.0-coq-8.14
           - mathcomp/mathcomp:1.15.0-coq-8.15
           - mathcomp/mathcomp:1.15.0-coq-8.16
-          - mathcomp/mathcomp:1.15.0-coq-dev
           - mathcomp/mathcomp-dev:coq-8.15 # (without coq-native for now)
           - mathcomp/mathcomp-dev:coq-8.16 # (without coq-native for now)
           - mathcomp/mathcomp-dev:coq-dev # (without coq-native for now)

--- a/src/mpoly.v
+++ b/src/mpoly.v
@@ -4466,8 +4466,9 @@ apply/eqP; rewrite eq_sym eqEcard; apply/andP; split.
   apply/negP=> /imsetP [/=] x _ /eqP.
   by rewrite eqE /= eq_sym ltn_eqF.
 have := disjoint_S n k; rewrite -leq_card_setU=> /eqP->.
-rewrite !card_imset //= ?card_draws /=; first last.
-  by apply/inj_swiden. by apply/inj_mDswiden.
+rewrite !card_imset //= ?card_draws /=;
+  try exact/inj_swiden; try exact/inj_mDswiden.
+  (* remove the line above once requiring Coq >= 8.17 *)
 by rewrite !card_ord binS.
 Qed.
 


### PR DESCRIPTION
We discovered in MathComp CI that multinomials no longer compiles with Coq master (likely since https://github.com/coq/coq/pull/16293).
Here is a fix that should be backward compatible (let's wait for CI confirmation).