### PR TITLE
add coq_makefile build method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,25 @@
-# -*- Makefile -*-
+# KNOWNTARGETS will not be passed along to CoqMakefile
+KNOWNTARGETS := CoqMakefile extra-stuff extra-stuff2
+# KNOWNFILES will not get implicit targets from the final rule, and so
+# depending on them won't invoke the submake
+# Warning: These files get declared as PHONY, so any targets depending
+# on them always get rebuilt
+KNOWNFILES   := Makefile _CoqProject
 
-# --------------------------------------------------------------------
-DUNEOPTS ?=
-DUNE     := dune $(DUNEOPTS)
+.DEFAULT_GOAL := invoke-coqmakefile
 
-# --------------------------------------------------------------------
-.PHONY: default build clean
+CoqMakefile: Makefile _CoqProject
+	$(COQBIN)coq_makefile -f _CoqProject -o CoqMakefile
 
-default: build
+invoke-coqmakefile: CoqMakefile
+	$(MAKE) --no-print-directory -f CoqMakefile $(filter-out $(KNOWNTARGETS),$(MAKECMDGOALS))
 
-build:
-	$(DUNE) build
+.PHONY: invoke-coqmakefile $(KNOWNFILES)
 
-clean:
-	$(DUNE) clean
+####################################################################
+##                      Your targets here                         ##
+####################################################################
+
+# This should be the last rule, to handle any targets not declared above
+%: invoke-coqmakefile
+	@true

--- a/_CoqProject
+++ b/_CoqProject
@@ -3,4 +3,10 @@
 -arg -w -arg -redundant-canonical-projection
 -arg -w -arg -projection-no-head-constant
 
--R _build/default/src mathcomp.multinomials
+-R src mathcomp.multinomials
+
+src/freeg.v
+src/monalg.v
+src/mpoly.v
+src/ssrcomplements.v
+src/xfinmap.v

--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,3 @@
+(lang dune 2.8)
+(using coq 0.3)
+(name multinomials)

--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,0 @@
-(lang dune 2.8)
-(using coq 0.3)
-(name multinomials)


### PR DESCRIPTION
Use the `coq_makefile` method which is [well documented](https://coq.inria.fr/distrib/current/refman/practical-tools/utilities.html?highlight=coq_makefile#building-a-coq-project-with-coq-makefile). This PR should fix both https://github.com/math-comp/multinomials/issues/58 and https://github.com/math-comp/multinomials/issues/75 .