### PR TITLE
remove deprecated warnings

### DIFF
--- a/src/freeg.v
+++ b/src/freeg.v
@@ -243,7 +243,7 @@ Section FreegTheory.
 
   (* ------------------------------------------------------------------ *)
   Section ZLift.
-  Context (R : ringType) (M : lmodType R) (K : choiceType) (f : K -> M).
+  Context (R : pzRingType) (M : lmodType R) (K : choiceType) (f : K -> M).
   Implicit Types (rD : prefreeg R K) (D : {freeg K / R}) (s : seq (R * K)).
   Implicit Types (z k : R) (x y : K).
 
@@ -316,7 +316,7 @@ Section FreegTheory.
   End ZLift.
 
   (* -------------------------------------------------------------------- *)
-  Context (R : ringType) (K : choiceType).
+  Context (R : pzRingType) (K : choiceType).
   Implicit Types (rD : prefreeg R K) (D : {freeg K / R}) (s : seq (R * K)).
   Implicit Types (z k : R) (x y : K).
 
@@ -476,7 +476,7 @@ Notation "<< p >>"      := [freeg [:: (1, p)]].
 (* -------------------------------------------------------------------- *)
 Module FreegZmodType.
   Section Defs.
-    Context (R : ringType) (K : choiceType).
+    Context (R : pzRingType) (K : choiceType).
     Implicit Types (rD : prefreeg R K) (D : {freeg K / R}) (s : seq (R * K)).
     Implicit Types (z k : R) (x y : K).
 
@@ -560,7 +560,7 @@ Export FreegZmodType.Exports.
 
 (* -------------------------------------------------------------------- *)
 Section FreegZmodTypeTheory.
-  Context (R : ringType) (K : choiceType).
+  Context (R : pzRingType) (K : choiceType).
   Implicit Types (x y z : K) (k : R) (D: {freeg K / R}).
 
   Local Notation coeff := (@coeff R K).
@@ -614,10 +614,6 @@ Section FreegZmodTypeTheory.
     move=> y; rewrite mem_dom coeffU mem_seq1.
     by case: (eqVneq x); rewrite /= ?(mulr0, mulr1, eqxx).
   Qed.
-
-  (* -------------------------------------------------------------------*)
-  Lemma domU1 z : dom (<< z >> : {freeg K / R}) = [:: z].
-  Proof. by rewrite domU ?oner_eq0. Qed.
 
   (* -------------------------------------------------------------------*)
   Lemma domN D : dom (-D) =i dom D.
@@ -746,9 +742,14 @@ Section FreegZmodTypeTheory.
   Qed.
 End FreegZmodTypeTheory.
 
+(* -------------------------------------------------------------------*)
+Lemma domU1 (K : choiceType) (R : nzRingType) z :
+  dom (<< z >> : {freeg K / R}) = [:: z].
+Proof. by rewrite domU ?oner_eq0. Qed.
+
 (* -------------------------------------------------------------------- *)
 Section FreeglModType.
-  Context (R : ringType) (K : choiceType).
+  Context (R : pzRingType) (K : choiceType).
   Implicit Types (x y z : K) (c k : R) (D: {freeg K / R}).
 
   Local Notation coeff := (@coeff R K).
@@ -786,7 +787,7 @@ End FreeglModType.
 
 (* -------------------------------------------------------------------- *)
 Section FreeglModTheory.
-  Context (R : ringType) (K : choiceType).
+  Context (R : pzRingType) (K : choiceType).
   Implicit Types (x y z : K) (c k : R) (D : {freeg K / R}).
 
   Local Notation coeff := (@coeff R K).
@@ -920,7 +921,7 @@ End FreegCmpDom.
 
 (* -------------------------------------------------------------------- *)
 Section FreegMap.
-  Context (G : ringType) (K : choiceType) (P : pred K) (f : G -> G).
+  Context (G : pzRingType) (K : choiceType) (P : pred K) (f : G -> G).
   Implicit Types (D : {freeg K / G}).
 
   Definition fgmap D := \sum_(z <- dom D | P z) << f (coeff z D) *g z >>.
@@ -1091,7 +1092,7 @@ End PosFreegDeg.
 
 (* -------------------------------------------------------------------- *)
 Section FreegIndDom.
-  Context (R : ringType) (K : choiceType) (F : pred K).
+  Context (R : pzRingType) (K : choiceType) (F : pred K).
   Context (P : {freeg K / R} -> Type).
   Implicit Types (D : {freeg K / R}).
 
@@ -1149,7 +1150,7 @@ Section FreegIndDom.
   Qed.
 End FreegIndDom.
 
-Lemma freeg_ind_dom  (R : ringType) (K : choiceType) (F : pred K):
+Lemma freeg_ind_dom  (R : pzRingType) (K : choiceType) (F : pred K):
      forall (P : {freeg K / R} -> Prop),
      (forall D : {freeg K / R},
        [predI dom (G:=R) (K:=K) D & [predC F]] =1 pred0 -> P D)
@@ -1161,7 +1162,7 @@ Proof. by move=> P; apply/(@freeg_rect_dom R K F P). Qed.
 
 (* -------------------------------------------------------------------- *)
 Section FreegIndDom0.
-  Context (R : ringType) (K : choiceType) (P : {freeg K / R} -> Type).
+  Context (R : pzRingType) (K : choiceType) (P : {freeg K / R} -> Type).
   Context (H0 : P 0).
   Context (HS : forall k x D, x \notin dom D -> k != 0 ->
                               P D -> P (<< k *g x >> + D)).
@@ -1175,7 +1176,7 @@ Section FreegIndDom0.
   Qed.
 End FreegIndDom0.
 
-Lemma freeg_ind_dom0 (R : ringType) (K : choiceType):
+Lemma freeg_ind_dom0 (R : pzRingType) (K : choiceType):
   forall (P : {freeg K / R} -> Prop),
        P 0
     -> (forall (k : R) (x : K) (D : {freeg K / R}),

--- a/src/monalg.v
+++ b/src/monalg.v
@@ -127,16 +127,16 @@ Module Exports. HB.reexport. End Exports.
 Export Exports.
 
 (* -------------------------------------------------------------------- *)
-Definition mmorphism (M : monomType) (S : ringType) (f : M -> S) :=
+Definition mmorphism (M : monomType) (S : pzRingType) (f : M -> S) :=
   {morph f : x y / (x * y)%M >-> (x * y)%R} * (f 1%M = 1) : Prop.
 
 HB.mixin Record isMultiplicative
-    (M : monomType) (S : ringType) (apply : M -> S) := {
+    (M : monomType) (S : pzRingType) (apply : M -> S) := {
   mmorphism_subproof : mmorphism apply;
 }.
 
 #[mathcomp(axiom="multiplicative")]
-HB.structure Definition MMorphism (M : monomType) (S : ringType) :=
+HB.structure Definition MMorphism (M : monomType) (S : pzRingType) :=
   {f of isMultiplicative M S f}.
 
 Module MMorphismExports.
@@ -152,7 +152,7 @@ Export MMorphismExports.
 
 (* -------------------------------------------------------------------- *)
 Section MMorphismTheory.
-Variables (M : monomType) (S : ringType) (f : {mmorphism M -> S}).
+Variables (M : monomType) (S : pzRingType) (f : {mmorphism M -> S}).
 
 Lemma mmorph1 : f 1%M = 1.
 Proof. exact: mmorphism_subproof.2. Qed.
@@ -198,10 +198,10 @@ Definition msupp (g : {malg G[K]}) : {fset K} := finsupp (malg_val g).
 
 End MalgBaseOp.
 
-Arguments mcoeff  {K G} x%monom_scope g%ring_scope.
+Arguments mcoeff  {K G} x%_monom_scope g%_ring_scope.
 Arguments mkmalg  {K G} _.
-Arguments mkmalgU {K G} k%monom_scope x%ring_scope.
-Arguments msupp   {K G} g%ring_scope.
+Arguments mkmalgU {K G} k%_monom_scope x%_ring_scope.
+Arguments msupp   {K G} g%_ring_scope.
 
 (* -------------------------------------------------------------------- *)
 Notation "g @_ k" := (mcoeff k g).
@@ -463,7 +463,7 @@ End MalgMonomTheory.
 
 (* -------------------------------------------------------------------- *)
 Section MAlgLMod.
-Context (K : choiceType) (R : ringType).
+Context (K : choiceType) (R : pzRingType).
 
 Definition fgscale c g : {malg R[K]} := \sum_(k <- msupp g) << c * g@_k *g k >>.
 
@@ -494,7 +494,7 @@ End MAlgLMod.
 
 (* -------------------------------------------------------------------- *)
 Section MAlgLModTheory.
-Context {K : choiceType} {R : ringType}.
+Context {K : choiceType} {R : pzRingType}.
 
 Implicit Types (g : {malg R[K]}).
 
@@ -539,7 +539,7 @@ Definition mcoeffsE :=
 
 (* -------------------------------------------------------------------- *)
 Section MAlgRingType.
-Context (K : monomType) (R : ringType).
+Context (K : monomType) (R : pzRingType).
 
 Implicit Types (g : {malg R[K]}) (k l : K).
 
@@ -665,18 +665,28 @@ rewrite [LHS](big_morph (fgmul _) (fun _ _ => fgmulgDr _ _ _) (fgmulg0 _)).
 by rewrite fgmulEr1; apply/eq_bigr=> k3 _; rewrite !fgmulUU mulrA mulmA.
 Qed.
 
-Lemma fgoner_eq0 : fgone != 0.
-Proof. by apply/eqP/malgP=> /(_ 1%M) /eqP; rewrite !mcoeffsE oner_eq0. Qed.
-
-HB.instance Definition _ := GRing.Zmodule_isRing.Build (malg K R)
-  fgmulA fgmul1g fgmulg1 fgmulgDl fgmulgDr fgoner_eq0.
-HB.instance Definition _ := GRing.Ring.on {malg R[K]}.
+HB.instance Definition _ := GRing.Zmodule_isPzRing.Build (malg K R)
+  fgmulA fgmul1g fgmulg1 fgmulgDl fgmulgDr.
+HB.instance Definition _ := GRing.PzRing.on {malg R[K]}.
 
 End MAlgRingType.
 
+
+(* -------------------------------------------------------------------- *)
+Section MAlgNzRingType.
+Context (K : monomType) (R : nzRingType).
+
+Lemma fgoner_eq0 : fgone K R != 0.
+Proof. by apply/eqP/malgP=> /(_ 1%M) /eqP; rewrite !mcoeffsE oner_eq0. Qed.
+
+HB.instance Definition _ :=
+  GRing.PzSemiRing_isNonZero.Build (malg K R) fgoner_eq0.
+
+End MAlgNzRingType.
+
 (* -------------------------------------------------------------------- *)
 Section MAlgRingTheory.
-Context (K : monomType) (R : ringType).
+Context (K : monomType) (R : pzRingType).
 
 Implicit Types (g : {malg R[K]}) (k l : K).
 
@@ -685,9 +695,6 @@ Proof. by []. Qed.
 
 Lemma mcoeffU1 k k' : (<< k >> : {malg R[K]})@_k' = (k == k')%:R.
 Proof. by rewrite mcoeffU. Qed.
-
-Lemma msuppU1 k : @msupp _ R << k >> = [fset k].
-Proof. by rewrite msuppU oner_eq0. Qed.
 
 Lemma malgME g1 g2 :
   g1 * g2 = \sum_(k1 <- msupp g1) \sum_(k2 <- msupp g2)
@@ -809,15 +816,30 @@ HB.instance Definition _ m :=
 Lemma fgscaleAl c g1 g2 : c *: (g1 * g2) = (c *: g1) * g2.
 Proof. by rewrite -!mul_malgC mulrA. Qed.
 
-HB.instance Definition _ := GRing.Lmodule_isLalgebra.Build R (malg K R)
-  fgscaleAl.
-HB.instance Definition _ := GRing.Lalgebra.on {malg R[K]}.
-
 End MAlgRingTheory.
 
 (* -------------------------------------------------------------------- *)
+Section MAlgNzRingTheory.
+Context (K : monomType) (R : nzRingType).
+
+Implicit Types (g : {malg R[K]}) (k l : K).
+
+Lemma msuppU1 k : @msupp _ R << k >> = [fset k].
+Proof. by rewrite msuppU oner_eq0. Qed.
+
+Lemma xxfgscaleAl c g1 g2 : c *: (g1 * g2) = (c *: g1) * g2.
+Proof. by rewrite -!mul_malgC mulrA. Qed.
+
+HB.instance Definition _ := GRing.Lmodule_isLalgebra.Build R (malg K R)
+  (@fgscaleAl K R).
+HB.instance Definition _ := GRing.Lalgebra.on {malg R[K]}.
+
+End MAlgNzRingTheory.
+
+
+(* -------------------------------------------------------------------- *)
 Section MalgComRingType.
-Context (K : conomType) (R : comRingType).
+Context (K : conomType) (R : comPzRingType).
 
 Lemma fgmulC : @commutative {malg R[K]} _ *%R.
 Proof.
@@ -826,19 +848,25 @@ apply/eq_bigr=> /= k1 _; apply/eq_bigr=> /= k2 _.
 by rewrite mulrC [X in X==k]mulmC.
 Qed.
 
-HB.instance Definition _ := GRing.Ring_hasCommutativeMul.Build (malg K R)
+HB.instance Definition _ := GRing.PzRing_hasCommutativeMul.Build (malg K R)
   fgmulC.
+
+End MalgComRingType.
+
+(* -------------------------------------------------------------------- *)
+Section MalgComNzRingType.
+Context (K : conomType) (R : comNzRingType).
 
 HB.instance Definition _ := GRing.Lalgebra_isComAlgebra.Build R (malg K R).
 
 HB.instance Definition _ := GRing.ComAlgebra.on {malg R[K]}.
 
-End MalgComRingType.
+End MalgComNzRingType.
 
 (* -------------------------------------------------------------------- *)
 Section MalgMorphism.
 Section Defs.
-Context (K : choiceType) (G : zmodType) (S : ringType).
+Context (K : choiceType) (G : zmodType) (S : pzRingType).
 Context (f : G -> S) (h : K -> S).
 
 Definition mmap g := \sum_(k <- msupp g) f g@_k * h k.
@@ -850,7 +878,7 @@ End Defs.
 Local Notation "g ^[ f , h ]" := (mmap f h g).
 
 Section BaseTheory.
-Context (K : choiceType) (G : zmodType) (S : ringType).
+Context (K : choiceType) (G : zmodType) (S : pzRingType).
 Context {f : {additive G -> S}} {h : K -> S}.
 
 Lemma mmapEw (d : {fset K}) g : msupp g `<=` d ->
@@ -865,7 +893,7 @@ Proof. by rewrite (mmapEw msuppU_le) big_seq_fset1 mcoeffUU. Qed.
 End BaseTheory.
 
 Section Additive.
-Context (K : choiceType) (G : zmodType) (S : ringType).
+Context (K : choiceType) (G : zmodType) (S : pzRingType).
 Context {f : {additive G -> S}} {h : K -> S}.
 
 Lemma mmap_is_additive : additive (mmap f h).
@@ -889,7 +917,7 @@ Lemma mmapMNn n : {morph mmap: x / x *- n} . Proof. exact: raddfMNn. Qed.
 End Additive.
 
 Section CommrMultiplicative.
-Context (K : monomType) (R : ringType) (S : ringType).
+Context (K : monomType) (R : pzRingType) (S : pzRingType).
 Context {f : {rmorphism R -> S}} {h : {mmorphism K -> S}}.
 
 Implicit Types (g : {malg R[K]}).
@@ -919,7 +947,7 @@ End CommrMultiplicative.
 
 (* -------------------------------------------------------------------- *)
 Section Multiplicative.
-Context (K : monomType) (R : ringType) (S : comRingType).
+Context (K : monomType) (R : pzRingType) (S : comPzRingType).
 Context {f : {rmorphism R -> S}} {h : {mmorphism K -> S}}.
 
 Implicit Types (g : {malg R[K]}).
@@ -934,7 +962,7 @@ End Multiplicative.
 
 (* -------------------------------------------------------------------- *)
 Section Linear.
-Context (K : monomType) (R : comRingType) {h : {mmorphism K -> R}}.
+Context (K : monomType) (R : comPzRingType) {h : {mmorphism K -> R}}.
 
 Lemma mmap_is_linear : scalable_for *%R (mmap idfun h).
 Proof. by move=> /= c g; rewrite -mul_malgC rmorphM /= mmapC. Qed.
@@ -1025,7 +1053,7 @@ End MonalgOverOpp.
 
 (* -------------------------------------------------------------------- *)
 Section MonalgOverSemiring.
-Context (K : monomType) (R : ringType) (S : semiringClosed R).
+Context (K : monomType) (R : pzRingType) (S : semiringClosed R).
 
 Local Notation monalgOver := (@monalgOver K R).
 
@@ -1064,7 +1092,7 @@ Qed.
 End MonalgOverSemiring.
 
 Section MonalgOverRing.
-Context (K : monomType) (R : ringType) (ringS : subringClosed R).
+Context (K : monomType) (R : pzRingType) (ringS : subringClosed R).
 
 HB.instance Definition _ := GRing.isMulClosed.Build _ (monalgOver_pred ringS)
   (monalgOver_mulr_closed K ringS).

--- a/src/mpoly.v
+++ b/src/mpoly.v
@@ -35,7 +35,7 @@
 (*          [mpoly D] == the multivariate polynomial constructed from a free  *)
 (*                       sum in {freeg 'X_{1..n} / R}                         *)
 (*  0, 1, - p, p + q, == the usual ring operations: {mpoly R} has a canonical *)
-(* p * q, p ^+ n, ...    ringType structure, which is commutative / integral  *)
+(* p * q, p ^+ n, ...    pzRingType structure, which is commutative / integral  *)
 (*                       when R is commutative / integral, respectively.      *)
 (*       {ipoly R[n]} == the type obtained by iterating the univariate        *)
 (*                       polynomial type, with R as base ring.                *)
@@ -77,7 +77,7 @@
 (* -------------------------------------------------------------------------- *)
 
 (* -------------------------------------------------------------------- *)
-From Corelib Require Import Setoid.
+From Coq Require Import Setoid.
 From HB Require Import structures.
 From mathcomp Require Import ssreflect ssrfun ssrbool eqtype ssrnat seq path.
 From mathcomp Require Import choice fintype tuple finfun bigop finset binomial.
@@ -248,7 +248,9 @@ Definition mnm0 := [multinom 0 | _ < n].
 Definition mnm1 (c : 'I_n) := [multinom c == i | i < n].
 Definition mnm_add m1 m2 := [multinom m1 i + m2 i | i < n].
 Definition mnm_sub m1 m2 := [multinom m1 i - m2 i | i < n].
-Definition mnm_muln m i := nosimpl iterop _ i mnm_add m mnm0.
+Definition mnm_muln m i := iterop i mnm_add m mnm0.
+
+Arguments mnm_muln : simpl never.
 
 Local Notation "0"         := mnm0 : multi_scope.
 Local Notation "'U_(' n )" := (mnm1 n) : multi_scope.
@@ -370,6 +372,8 @@ by move=> lt0_mi j; rewrite mnm1E; case: eqP=> // <-.
 Qed.
 
 End MultinomMonoid.
+
+Arguments mnm_muln : simpl never.
 
 (* -------------------------------------------------------------------- *)
 Notation "+%MM" := (@mnm_add _).
@@ -743,7 +747,7 @@ End Mlcm.
 
 (* -------------------------------------------------------------------- *)
 Section MPolyDef.
-Context (n : nat) (R : ringType).
+Context (n : nat) (R : pzRingType).
 
 Inductive mpoly := MPoly of {freeg 'X_{1..n} / R}.
 
@@ -761,7 +765,7 @@ Notation "[ 'mpoly' D ]" := (@MPoly _ _ D).
 
 (* -------------------------------------------------------------------- *)
 Section MPolyTheory.
-Context (n : nat) (R : ringType).
+Context (n : nat) (R : pzRingType).
 Implicit Types (p q r : {mpoly R[n]}) (D : {freeg 'X_{1..n} / R}).
 
 Lemma mpoly_valK D : [mpoly D] = D :> {freeg _ / _}.
@@ -796,7 +800,9 @@ Proof. by rewrite mcoeff_MPoly coeffU eq_sym. Qed.
 Lemma mpolyCK : cancel mpolyC (mcoeff 0%MM).
 Proof. by move=> c; rewrite mcoeffC eqxx mulr1. Qed.
 
-Definition msupp p : seq 'X_{1..n} := nosimpl (dom p).
+Definition msupp p : seq 'X_{1..n} := dom p.
+
+Arguments msupp : simpl never.
 
 Lemma msuppE p : msupp p = dom p :> seq _.
 Proof. by []. Qed.
@@ -816,9 +822,6 @@ Proof. by rewrite msuppE mem_dom /mcoeff negbK. Qed.
 Lemma msupp0 : msupp 0%:MP = [::].
 Proof. by rewrite msuppE /= freegU0 dom0. Qed.
 
-Lemma msupp1 : msupp 1%:MP = [:: 0%MM].
-Proof. by rewrite msuppE /= domU1. Qed.
-
 Lemma msuppC (c : R) :
   msupp c%:MP = if c == 0 then [::] else [:: 0%MM].
 Proof. by have [->|nz_c] := eqVneq; [rewrite msupp0 | rewrite msuppE domU]. Qed.
@@ -831,6 +834,22 @@ Proof. by case: p=> p; apply/mpoly_eqP; rewrite /= -{1}[p]freeg_sumE. Qed.
 
 End MPolyTheory.
 
+Arguments msupp : simpl never.
+
+(* -------------------------------------------------------------------- *)
+Section MNzPolyTheory.
+
+Context (n : nat) (R : nzRingType).
+Implicit Types (p q r : {mpoly R[n]}) (D : {freeg 'X_{1..n} / R}).
+
+Local Notation "c %:MP" := (@mpolyC n R c) : ring_scope.
+
+Lemma msupp1 : msupp 1%:MP = [:: 0%MM].
+Proof. by rewrite msuppE /= domU1. Qed.
+
+End MNzPolyTheory.
+
+
 Notation "c %:MP" := (mpolyC _ c) : ring_scope.
 Notation "c %:MP_[ n ]" := (mpolyC n c) : ring_scope.
 
@@ -840,7 +859,7 @@ Notation "p @_ i" := (mcoeff i p) : ring_scope.
 
 (* -------------------------------------------------------------------- *)
 Section NVar0.
-Context (n : nat) (R : ringType).
+Context (n : nat) (R : pzRingType).
 Implicit Types (p q r : {mpoly R[n]}).
 
 Lemma nvar0_mnmE : @all_equal_to 'X_{1..0} 0%MM.
@@ -856,7 +875,7 @@ End NVar0.
 
 (* -------------------------------------------------------------------- *)
 Section MPolyZMod.
-Context (n : nat) (R : ringType).
+Context (n : nat) (R : pzRingType).
 Implicit Types (p q r : {mpoly R[n]}).
 
 Definition mpoly_opp p := [mpoly - mpoly_val p].
@@ -971,7 +990,7 @@ Notation "[ 'measure' 'of' f ]" := (Measure.clone _ f _)
 
 (* -------------------------------------------------------------------- *)
 Section MMeasure.
-Context (n : nat) (R : ringType) (mf : measure n).
+Context (n : nat) (R : pzRingType) (mf : measure n).
 Implicit Types (m : 'X_{1..n}) (p q : {mpoly R[n]}).
 
 Lemma mfE m : mf m = (\sum_(i < n) (m i) * mf U_(i)%MM)%N.
@@ -999,7 +1018,7 @@ End MMeasure.
 
 (* -------------------------------------------------------------------- *)
 Section MSuppZMod.
-Context (n : nat) (R : ringType).
+Context (n : nat) (R : pzRingType).
 Implicit Types (p q r : {mpoly R[n]}) (D : {freeg 'X_{1..n} / R}).
 
 Lemma msuppN p : perm_eq (msupp (-p)) (msupp p).
@@ -1085,7 +1104,7 @@ End MWeight.
 Notation mweight p := (@mmeasure _ _ (Measure.clone _ mnmwgt _) p).
 
 Section MSize.
-Context (n : nat) (R : ringType).
+Context (n : nat) (R : pzRingType).
 Implicit Types (m : 'X_{1..n}) (p : {mpoly R[n]}).
 
 Lemma msizeE p : msize p = (\max_(m <- msupp p) (mdeg m).+1)%N.
@@ -1103,7 +1122,7 @@ End MSize.
 
 (* -------------------------------------------------------------------- *)
 Section MMeasureZMod.
-Context (n : nat) (R : ringType) (mf : measure n).
+Context (n : nat) (R : pzRingType) (mf : measure n).
 Implicit Types (c : R) (m : 'X_{1..n}) (p q : {mpoly R[n]}).
 
 Local Notation mmeasure := (@mmeasure n R mf).
@@ -1165,7 +1184,7 @@ Definition msize_poly_eq0 n R := @mmeasure_poly_eq0 n R mdeg.
 Definition msize_msupp0   n R := @mmeasure_msupp0 n R mdeg.
 
 (* -------------------------------------------------------------------- *)
-Definition polyn (R : ringType) :=
+Definition polyn (R : nzRingType) :=
   fix polyn n := if n is p.+1 then {poly (polyn p)} else R.
 
 Definition ipoly (T : Type) : Type := T.
@@ -1174,15 +1193,15 @@ Notation "{ 'ipoly' T [ n ] }"   := (polyn T n).
 Notation "{ 'ipoly' T [ n ] }^p" := (ipoly {ipoly T[n]}).
 
 Section IPoly.
-Context (R : ringType) (n : nat).
+Context (R : nzRingType) (n : nat).
 
-HB.instance Definition _ := GRing.Ring.on {ipoly R[n]}^p.
+HB.instance Definition _ := GRing.NzRing.on {ipoly R[n]}^p.
 
 End IPoly.
 
 (* -------------------------------------------------------------------- *)
 Section Inject.
-Context (R : ringType).
+Context (R : nzRingType).
 
 Fixpoint inject n m (p : {ipoly R[n]}) : {ipoly R[m + n]} :=
   if m is m'.+1 return {ipoly R[m + n]} then (inject m' p)%:P else p.
@@ -1283,7 +1302,7 @@ End Inject.
 
 (* -------------------------------------------------------------------- *)
 Section MPolyRing.
-Context (n : nat) (R : ringType).
+Context (n : nat) (R : nzRingType).
 Implicit Types (p q r : {mpoly R[n]}) (m : 'X_{1..n}).
 
 Local Notation "`| p |" := (msize p) : ring_scope.
@@ -1477,9 +1496,9 @@ Qed.
 Lemma poly_oner_neq0 : 1%:MP != 0 :> {mpoly R[n]}.
 Proof. by rewrite mpolyC_eq oner_eq0. Qed.
 
-HB.instance Definition _ := GRing.Zmodule_isRing.Build (mpoly n R)
+HB.instance Definition _ := GRing.Zmodule_isNzRing.Build (mpoly n R)
   poly_mulA poly_mul1m poly_mulm1 poly_mulDl poly_mulDr poly_oner_neq0.
-HB.instance Definition _ := GRing.Ring.on {mpoly R[n]}.
+HB.instance Definition _ := GRing.NzRing.on {mpoly R[n]}.
 
 Lemma mcoeff1 m : 1@_m = (m == 0%MM)%:R.
 Proof. by rewrite mcoeffC mul1r. Qed.
@@ -1614,7 +1633,7 @@ End MPolyRing.
 
 (* -------------------------------------------------------------------- *)
 Section MPolyVar.
-Context (n : nat) (R : ringType).
+Context (n : nat) (R : pzRingType).
 
 Definition mpolyX_def (m : 'X_{1..n}) : {mpoly R[n]} := [mpoly << m >>].
 
@@ -1625,10 +1644,12 @@ Definition mpolyX m : {mpoly R[n]} :=
 
 Canonical mpolyX_unlockable m := [unlockable of (mpolyX m)].
 
-Definition mX (k : 'I_n) : 'X_{1..n} :=
-  nosimpl [multinom (i == k : nat) | i < n].
+Definition mX (k : 'I_n) : 'X_{1..n} := [multinom (i == k : nat) | i < n].
 
 End MPolyVar.
+
+Arguments mX : simpl never.
+
 
 Notation "'X_[ R , m ]" := (@mpolyX _ R m).
 Notation "'X_[ m ]"     := (@mpolyX _ _ m).
@@ -1636,7 +1657,7 @@ Notation "'X_ i"        := (@mpolyX _ _ U_(i)).
 
 (* -------------------------------------------------------------------- *)
 Section MPolyVarTheory.
-Context (n : nat) (R : ringType).
+Context (n : nat) (R : nzRingType).
 Implicit Types (p q r : {mpoly R[n]}) (m : 'X_{1..n}).
 
 Local Notation "'X_[ m ]" := (@mpolyX n R m).
@@ -1853,7 +1874,7 @@ End MPolyVarTheory.
 
 (* -------------------------------------------------------------------- *)
 Section MPolyLead.
-Context (n : nat) (R : ringType).
+Context (n : nat) (R : nzRingType).
 Implicit Types (p q r : {mpoly R[n]}).
 
 Definition mlead p : 'X_{1..n} := (\join_(m <- msupp p) m)%O.
@@ -2179,7 +2200,7 @@ Notation mleadc p := (p@_(mlead p)).
 
 (* -------------------------------------------------------------------- *)
 Section MPolyLast.
-Context {R : ringType} {n : nat}.
+Context {R : pzRingType} {n : nat}.
 
 Definition mlast (p : {mpoly R[n]}) : 'X_{1..n} :=
   head 0%MM (sort <=%O (msupp p)).
@@ -2226,7 +2247,7 @@ End MPolyLast.
 
 (* -------------------------------------------------------------------- *)
 Section MPoly0.
-Context (R : ringType).
+Context (R : pzRingType).
 
 Lemma mpolyKC : cancel (@mcoeff 0 R 0%MM) (@mpolyC 0 R).
 Proof.
@@ -2239,7 +2260,7 @@ End MPoly0.
 
 (* -------------------------------------------------------------------- *)
 Section MPolyDeriv.
-Context (n : nat) (R : ringType).
+Context (n : nat) (R : nzRingType).
 Implicit Types (p q r : {mpoly R[n]}) (m : 'X_{1..n}).
 
 Definition mderiv (i : 'I_n) p :=
@@ -2568,7 +2589,7 @@ Notation "p ^`M ( i , n )" := (mderivm (U_(i) *+ n) p).
 
 (* -------------------------------------------------------------------- *)
 Section MPolyMorphism.
-Context (n : nat) (R S : ringType).
+Context (n : nat) (R S : nzRingType).
 Implicit Types (p q r : {mpoly R[n]}) (m : 'X_{1..n}).
 
 Section Defs.
@@ -2698,20 +2719,20 @@ End MPolyMorphism.
 Arguments mmapE [n R S h f p].
 
 (* -------------------------------------------------------------------- *)
-Lemma mmap1_eq n (R : ringType) (f1 f2 : 'I_n -> R) m :
+Lemma mmap1_eq n (R : nzRingType) (f1 f2 : 'I_n -> R) m :
   f1 =1 f2 -> mmap1 f1 m = mmap1 f2 m.
 Proof.
 move=> eq_f; rewrite /mmap1; apply/eq_bigr.
 by move=> /= i _; rewrite eq_f.
 Qed.
 
-Lemma mmap1_id n (R : ringType) m :
+Lemma mmap1_id n (R : nzRingType) m :
   mmap1 (fun i => 'X_i) m = 'X_[m] :> {mpoly R[n]}.
 Proof. by rewrite mpolyXE_id. Qed.
 
 (* -------------------------------------------------------------------- *)
 Section MPolyMorphismComm.
-Context (n : nat) (R : ringType) (S : comRingType).
+Context (n : nat) (R : nzRingType) (S : comNzRingType).
 Context (h : 'I_n -> S) (f : {rmorphism R -> S}).
 Implicit Types (p q r : {mpoly R[n]}).
 
@@ -2730,7 +2751,7 @@ End MPolyMorphismComm.
 
 (* -------------------------------------------------------------------- *)
 Section MPolyComRing.
-Context (n : nat) (R : comRingType).
+Context (n : nat) (R : comNzRingType).
 Implicit Types (p q r : {mpoly R[n]}).
 
 Lemma mpoly_mulC p q : p * q = q * p.
@@ -2739,9 +2760,9 @@ apply/mpolyP=> /= m; rewrite mcoeffM mcoeffMr.
 by apply: eq_bigr=> /= i _; rewrite mulrC.
 Qed.
 
-HB.instance Definition _ := GRing.Ring_hasCommutativeMul.Build (mpoly n R)
+HB.instance Definition _ := GRing.PzRing_hasCommutativeMul.Build (mpoly n R)
   mpoly_mulC.
-HB.instance Definition _ := GRing.ComRing.on {mpoly R[n]}.
+HB.instance Definition _ := GRing.ComNzRing.on {mpoly R[n]}.
 
 #[hnf]
 HB.instance Definition _ := GRing.Lalgebra_isComAlgebra.Build R {mpoly R[n]}.
@@ -2752,7 +2773,7 @@ End MPolyComRing.
 
 (* -------------------------------------------------------------------- *)
 Section MPolyComp.
-Context (n : nat) (R : ringType) (k : nat).
+Context (n : nat) (R : nzRingType) (k : nat).
 Implicit Types (p q : {mpoly R[n]}) (lp lq : n.-tuple {mpoly R[k]}).
 
 Definition comp_mpoly lq p : {mpoly R[k]} := mmap (@mpolyC _ R) (tnth lq) p.
@@ -2814,7 +2835,7 @@ End MPolyComp.
 Notation "p \mPo lq" := (@comp_mpoly _ _ _ lq p).
 
 Section MPolyCompComm.
-Context (n : nat) (R : comRingType) (k : nat) (lp : n.-tuple {mpoly R[k]}).
+Context (n : nat) (R : comNzRingType) (k : nat) (lp : n.-tuple {mpoly R[k]}).
 
 Lemma comp_mpoly_is_multiplicative : multiplicative (comp_mpoly lp).
 Proof. exact: mmap_is_multiplicative. Qed.
@@ -2827,7 +2848,7 @@ End MPolyCompComm.
 
 (* -------------------------------------------------------------------- *)
 Section MPolyCompHomo.
-Context (n : nat) (R : ringType).
+Context (n : nat) (R : nzRingType).
 Implicit Types (p q : {mpoly R[n]}).
 
 Lemma comp_mpoly_id p : p \mPo [tuple 'X_i | i < n] = p.
@@ -2842,7 +2863,7 @@ End MPolyCompHomo.
 
 (* -------------------------------------------------------------------- *)
 Section MEval.
-Context (n : nat) (R : ringType).
+Context (n : nat) (R : nzRingType).
 Implicit Types (p q r : {mpoly R[n]}) (v : 'I_n -> R).
 
 Definition meval v p := mmap idfun v p.
@@ -2894,7 +2915,7 @@ Notation "p .@[< v >]" := (@meval _ _ (nth v) p).
 
 (* -------------------------------------------------------------------- *)
 Section MEvalCom.
-Context (n k : nat) (R : comRingType).
+Context (n k : nat) (R : comNzRingType).
 Implicit Types (p q r : {mpoly R[n]}) (v : 'I_n -> R).
 
 Lemma meval_is_lrmorphism v : scalable_for *%R (meval v).
@@ -2913,7 +2934,7 @@ End MEvalCom.
 
 (* -------------------------------------------------------------------- *)
 Section MEvalComp.
-Context (n k : nat) (R : comRingType) (v : 'I_n -> R) (p : {mpoly R[k]}).
+Context (n k : nat) (R : comNzRingType) (v : 'I_n -> R) (p : {mpoly R[k]}).
 Context (lq : k.-tuple {mpoly R[n]}).
 
 Lemma comp_mpoly_meval : (p \mPo lq).@[v] = p.@[fun i => (tnth lq i).@[v]].
@@ -2928,7 +2949,7 @@ End MEvalComp.
 
 (* -------------------------------------------------------------------- *)
 Section MPolyMap.
-Context (n : nat) (R S : ringType).
+Context (n : nat) (R S : nzRingType).
 Implicit Types (p q r : {mpoly R[n]}).
 
 Definition map_mpoly (f : R -> S) p : {mpoly S[n]} :=
@@ -3001,7 +3022,7 @@ End MPolyMap.
 
 (* -------------------------------------------------------------------- *)
 Section MPolyMapComp.
-Context (n k : nat) (R S : ringType) (f : {rmorphism R -> S}).
+Context (n k : nat) (R S : nzRingType) (f : {rmorphism R -> S}).
 Context (lq : n.-tuple {mpoly R[k]}) (p : {mpoly R[n]}).
 
 Local Notation "p ^f" := (map_mpoly f p).
@@ -3020,7 +3041,7 @@ End MPolyMapComp.
 
 (* -------------------------------------------------------------------- *)
 Section MPolyOver.
-Context (n : nat) (R : ringType).
+Context (n : nat) (R : nzRingType).
 
 Definition mpolyOver_pred (S : {pred R}) :=
   fun p : {mpoly R[n]} => all (mem S) [seq p@_m | m <- msupp p].
@@ -3225,7 +3246,7 @@ Qed.
 Lemma mpoly_inv_out : {in [predC mpoly_unit], mpoly_inv =1 id}.
 Proof.  by rewrite /mpoly_inv => p /negbTE /= ->. Qed.
 
-HB.instance Definition _ := GRing.ComRing_hasMulInverse.Build (mpoly n R)
+HB.instance Definition _ := GRing.ComNzRing_hasMulInverse.Build (mpoly n R)
   mpoly_mulVp mpoly_intro_unit mpoly_inv_out.
 HB.instance Definition _ := GRing.ComUnitRing.on {mpoly R[n]}.
 
@@ -3239,7 +3260,7 @@ End MPolyIdomain.
 
 (* -------------------------------------------------------------------- *)
 Section MWeightTheory.
-Context (n : nat) (R : ringType).
+Context (n : nat) (R : pzRingType).
 Implicit Types (m : 'X_{1..n}) (p : {mpoly R[n]}).
 
 Lemma leq_mdeg_mnmwgt m : mdeg m <= mnmwgt m.
@@ -3259,7 +3280,7 @@ End MWeightTheory.
 
 (* -------------------------------------------------------------------- *)
 Section MPerm.
-Context (n : nat) (R : ringType).
+Context (n : nat) (R : pzRingType).
 Implicit Types (m : 'X_{1..n}).
 
 Local Notation "m # s" := [multinom m (s i) | i < n]
@@ -3293,7 +3314,7 @@ End MPerm.
 
 (* -------------------------------------------------------------------- *)
 Section MPolySym.
-Context (n : nat) (R : ringType).
+Context (n : nat) (R : nzRingType).
 Implicit Types (p q r : {mpoly R[n]}).
 
 Definition msym (s : 'S_n) p : {mpoly R[n]} :=
@@ -3474,7 +3495,7 @@ Arguments symmetric {n R}.
 
 (* -------------------------------------------------------------------- *)
 Section MPolySymComp.
-Context (n : nat) (R : ringType).
+Context (n : nat) (R : nzRingType).
 
 Lemma mcomp_sym k (p : {mpoly R[n]}) (t : n.-tuple {mpoly R[k]}) :
   (forall i : 'I_n, t`_i \is symmetric) -> p \mPo t \is symmetric.
@@ -3489,7 +3510,7 @@ End MPolySymComp.
 
 (* -------------------------------------------------------------------- *)
 Section MPolySymCompCom.
-Context (n : nat) (R : comRingType).
+Context (n : nat) (R : comNzRingType).
 
 Local Notation "m # s" := [multinom m (s i) | i < n]
   (at level 40, left associativity, format "m # s").
@@ -3562,7 +3583,7 @@ End MPolySymUnit.
 
 (* -------------------------------------------------------------------- *)
 Section MElemPolySym.
-Context (n : nat) (R : ringType).
+Context (n : nat) (R : nzRingType).
 Implicit Types (p q r : {mpoly R[n]}) (h : {set 'I_n}).
 
 Definition mesym (k : nat) : {mpoly R[n]} :=
@@ -3847,7 +3868,7 @@ Local Notation "''s_' ( n , k )" := (@mesym n _ k).
 
 (* -------------------------------------------------------------------- *)
 Section MWiden.
-Context (n : nat) (R : ringType).
+Context (n : nat) (R : nzRingType).
 
 Definition mwiden (p : {mpoly R[n]}) : {mpoly R[n.+1]} :=
   mmap (@mpolyC _ _) (fun i => 'X_(widen i)) p.
@@ -4006,7 +4027,7 @@ End MWiden.
 
 (* -------------------------------------------------------------------- *)
 Section MPolyUni.
-Context (n : nat) (R : ringType).
+Context (n : nat) (R : nzRingType).
 Implicit Types (p q : {mpoly R[n.+1]}).
 
 Let X (i : 'I_n.+1) : {poly {mpoly R[n]}} :=
@@ -4016,7 +4037,9 @@ Let X (i : 'I_n.+1) : {poly {mpoly R[n]}} :=
   end.
 
 Definition muni (p : {mpoly R[n.+1]}) : {poly {mpoly R[n]}} :=
-  nosimpl (mmap (polyC \o @mpolyC _ _) X p).
+  mmap (polyC \o @mpolyC _ _) X p.
+
+Arguments muni : simpl never.
 
 Let XE m : mmap1 X m = 'X_[[multinom (m (widen i)) | i < n]] *: 'X^(m ord_max).
 Proof.
@@ -4086,6 +4109,8 @@ Lemma muniZ c p : muni (c *: p) = c%:MP *: muni p.
 Proof. by rewrite /muni mmapZ /= mul_polyC. Qed.
 
 End MPolyUni.
+
+Arguments muni : simpl never.
 
 (* -------------------------------------------------------------------- *)
 Section MESymViete.
@@ -4160,7 +4185,7 @@ rewrite !card_imset //= ?card_draws /=;
 by rewrite !card_ord binS.
 Qed.
 
-Lemma mesymSS (R : ringType) n k :
+Lemma mesymSS (R : nzRingType) n k :
   's_(n.+1, k.+1) = mw 's_(n, k.+1) + mw 's_(n, k) * 'X_(ord_max)
   :> {mpoly R[n.+1]}.
 Proof.
@@ -4261,7 +4286,7 @@ End MESymViete.
 
 (* -------------------------------------------------------------------- *)
 Section MESymFundamental.
-Context (n : nat) (R : comRingType).
+Context (n : nat) (R : comNzRingType).
 Implicit Types (m : 'X_{1..n}).
 
 Local Notation "m # s" := [multinom m (s i) | i < n]
@@ -4438,8 +4463,9 @@ have: p \is symmetric -> { n : nat | (symfn n p).2 = 0 }.
 by case: (p \is symmetric)=> [[]// k eq|_]; [exists k | exists 0%N].
 Qed.
 
-Definition symf (p : {mpoly R[n]}) :=
-  nosimpl (symfn (tag (symfnS p)) p).1.
+Definition symf (p : {mpoly R[n]}) := (symfn (tag (symfnS p)) p).1.
+
+Arguments symf : simpl never.
 
 Lemma symfP (p : {mpoly R[n]}) : p \is symmetric -> p = symf p \mPo S.
 Proof.
@@ -4517,25 +4543,27 @@ Qed.
 
 End MESymFundamental.
 
+Arguments symf : simpl never.
+
 (* -------------------------------------------------------------------- *)
-Definition ishomog1_pred {n} {R : ringType}
+Definition ishomog1_pred {n} {R : pzRingType}
   (d : nat) (mf : measure n) : pred {mpoly R[n]}
   := fun p => all [pred m | mf m == d] (msupp p).
 Arguments ishomog1_pred _ _ _ _ _ /.
-Definition ishomog1 {n} {R : ringType}
+Definition ishomog1 {n} {R : pzRingType}
   (d : nat) (mf : measure n) : qualifier 0 {mpoly R[n]}
   := [qualify p | ishomog1_pred d mf p].
 
 (* -------------------------------------------------------------------- *)
-Definition ishomog_pred {n} {R : ringType} mf : pred {mpoly R[n]} :=
+Definition ishomog_pred {n} {R : pzRingType} mf : pred {mpoly R[n]} :=
   fun p => p \is ishomog1 (@mmeasure _ _ mf p).-1 mf.
 Arguments ishomog_pred _ _ _ _ /.
-Definition ishomog {n} {R : ringType} mf : qualifier 0 {mpoly R[n]} :=
+Definition ishomog {n} {R : pzRingType} mf : qualifier 0 {mpoly R[n]} :=
   [qualify p | ishomog_pred mf p].
 
 (* -------------------------------------------------------------------- *)
 Section MPolyHomogTheory.
-Context (n : nat) (R : ringType) (mf : measure n).
+Context (n : nat) (R : nzRingType) (mf : measure n).
 Implicit Types (p q : {mpoly R[n]}).
 
 Local Notation "d .-homog" := (@ishomog1 _ _ d mf)
@@ -4677,7 +4705,7 @@ Notation "'homog' mf" := (@ishomog _ _ mf)
 
 (* -------------------------------------------------------------------- *)
 Section HomogNVar0.
-Context (n : nat) (R : ringType).
+Context (n : nat) (R : nzRingType).
 
 Lemma nvar0_homog (mf : measure 0%N) (p : {mpoly R[0]}) :
   p \is 0.-homog for mf.
@@ -4691,7 +4719,7 @@ End HomogNVar0.
 
 (* -------------------------------------------------------------------- *)
 Section ProjHomog.
-Context (n : nat) (R : ringType) (mf : measure n).
+Context (n : nat) (R : nzRingType) (mf : measure n).
 Implicit Types (p q r : {mpoly R[n]}) (m : 'X_{1..n}).
 
 Local Notation mfsize p := (@mmeasure _ _ mf p).
@@ -4792,7 +4820,7 @@ End ProjHomog.
 
 (* -------------------------------------------------------------------- *)
 Section MPolyHomogType.
-Context (n : nat) (R : ringType) (d : nat).
+Context (n : nat) (R : nzRingType) (d : nat).
 
 Record dhomog :=
   DHomog { mpoly_of_dhomog :> {mpoly R[n]}; _ : mpoly_of_dhomog \is d.-homog }.
@@ -4810,14 +4838,14 @@ HB.instance Definition _ :=
 
 End MPolyHomogType.
 
-Lemma dhomog_is_dhomog n (R : ringType) d (p : dhomog n R d) :
+Lemma dhomog_is_dhomog n (R : nzRingType) d (p : dhomog n R d) :
   val p \is d.-homog.
 Proof. by case: p. Qed.
 
 #[global] Hint Extern 0 (is_true (_ \is _.-homog)) =>
   (by apply/dhomog_is_dhomog) : core.
 
-Definition indhomog n (R : ringType) d : {mpoly R[n]} -> dhomog n R d :=
+Definition indhomog n (R : nzRingType) d : {mpoly R[n]} -> dhomog n R d :=
   fun p => insubd (0 : dhomog n R d) p.
 
 Notation "[ ''dhomog_' d p ]" := (@indhomog _ _ d p)
@@ -4919,9 +4947,9 @@ by rewrite !mem_enum; apply/inj_s2m.
 Qed.
 
 (* -------------------------------------------------------------------- *)
-Context (n : nat) (R : ringType) (d : nat).
+Context (n : nat) (R : nzRingType) (d : nat).
 
-Lemma dhomog_vecaxiom: vector_axiom 'C(d + n, d) (dhomog n.+1 R d).
+Lemma dhomog_vecaxiom: Vector.axiom 'C(d + n, d) (dhomog n.+1 R d).
 Proof.
 pose b := sbasis n.+1 d.
 pose t := [tuple of nseq d (0 : 'I_n.+1)].
@@ -4973,7 +5001,7 @@ End MPolyHomogVec.
 
 (* -------------------------------------------------------------------- *)
 Section MSymHomog.
-Context (n : nat) (R : comRingType).
+Context (n : nat) (R : comNzRingType).
 Implicit Types (p q r : {mpoly R[n]}).
 
 Lemma msym_pihomog d p (s : 'S_n) :
@@ -4995,7 +5023,7 @@ End MSymHomog.
 
 (* -------------------------------------------------------------------- *)
 Section MESymFundamentalHomog.
-Context (n : nat) (R : comRingType).
+Context (n : nat) (R : comNzRingType).
 
 Local Notation S := [tuple mesym n R i.+1  | i < n].
 

--- a/src/ssrcomplements.v
+++ b/src/ssrcomplements.v
@@ -27,7 +27,7 @@ Proof. exact: tt || exact: Disp tt tt. Defined.
 End Order.
 
 (* -------------------------------------------------------------------- *)
-Lemma lreg_prod (T : eqType) (R : ringType) (r : seq T) (P : pred T) (F : T -> R):
+Lemma lreg_prod (T : eqType) (R : pzRingType) (r : seq T) (P : pred T) (F : T -> R):
       (forall x, x \in r -> P x -> GRing.lreg (F x))
    -> GRing.lreg (\prod_(x <- r | P x) F x).
 Proof.
@@ -214,7 +214,7 @@ End BigOpPair.
 (* -------------------------------------------------------------------- *)
 Section BigOpMulrn.
   Variable I : Type.
-  Variable R : ringType.
+  Variable R : pzRingType.
 
   Variable F : I -> R.
   Variable P : pred I.


### PR DESCRIPTION
I have removed all the deprecated warnings when compiling with `mathcomp 2.4`.
For the `ringType` warning, I've tried at the beginning. when possible, to replace it with `pzRingType`.
I have stopped at `MPolyRing` from there I have always used `nzRingType`.





